### PR TITLE
Update JDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM gradle:4.7.0-jdk8-alpine AS build
+FROM gradle:7.6-jdk8 AS build
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
 RUN gradle build --no-daemon 
 
-FROM openjdk:8-jre-slim
+FROM amazoncorretto:17
 
 EXPOSE 8080
 

--- a/Dockerfile.only-package
+++ b/Dockerfile.only-package
@@ -1,4 +1,4 @@
-FROM openjdk:8-jre-slim
+FROM amazoncorretto:17
 
 EXPOSE 8080
 


### PR DESCRIPTION
The OpenJDK image used in the Dockerfile is out of date; I believe the Gradle image is no longer maintained. This PR updates to more recent images, and the docker build/run commands work fine in it.

Great project, thanks!